### PR TITLE
Fix setting name for clean html

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -45,7 +45,7 @@ if (is_siteadmin()) {
         $templatecount = ATTO_TEMPLATES_TEMPLATE_COUNT;
     }
 
-    $settings->add(new admin_setting_configcheckbox('atto_templates/cleantext',
+    $settings->add(new admin_setting_configcheckbox('atto_templates/cleanhtml',
         new lang_string('cleanhtml', 'atto_templates'),
         new lang_string('cleanhtml_desc', 'atto_templates'),
         '1'));


### PR DESCRIPTION
The setting name is wrong, as you check after in the config object for `cleanhtml`.

```php
Notice: Undefined property: stdClass::$cleanhtml in 
/var/www/html/moodle/lib/editor/atto/plugins/templates/lib.php on line 60
```